### PR TITLE
ローカル関数の代わりにラムダ式を使うように変更

### DIFF
--- a/noc/noc/Program.cs
+++ b/noc/noc/Program.cs
@@ -100,14 +100,14 @@ namespace noc {
 
             var list = new List<Block>();
 
-            string Filter(Block block) {
+            Func<Block, string> Filter = block =>  {
                 var filtered = Block.InverseDictionary[block.BlockMode];
                 for (var item = StringInfo.GetTextElementEnumerator(block.Message); item.MoveNext();) {
                     filtered += inverseTable[block.BlockMode][item.GetTextElement()];
                 }
 
                 return filtered;
-            }
+            };
 
             foreach (var b in EncodeSplit(str)) {
                 if (b.BlockMode == Block.Mode.Base64) {


### PR DESCRIPTION
Mono C# compiler version
4.6.2.0がC#7のローカル関数に対応しておらずシェル芸bot上でコンパイルに失敗したため対応を入れましたので、一応Pull Reqもおくっておきます
（Dockerfileにあるようにdotnetの方を使えばよいのはそうなんですが……）

